### PR TITLE
fix this binding issue in map call in Chapter04/01/List.js

### DIFF
--- a/Chapter04/01/components/List.js
+++ b/Chapter04/01/components/List.js
@@ -73,7 +73,7 @@ export default class List extends HTMLElement {
     this.list.innerHTML = ''
 
     this.todos
-      .map(this.getTodoElement)
+      .map(this.getTodoElement.bind(this))
       .forEach(element => {
         this.list.appendChild(element)
       })


### PR DESCRIPTION
#### 1. Issue Identified
- An error occurred in the getTodoElement method where this was undefined, leading to a failure when calling createNewTodoNode(). This was due to improper this binding in the Array.prototype.map function.

#### 2. Root Cause Analysis
- The this.getTodoElement method was being called within map, but this was not automatically bound to the List instance, resulting in an undefined reference for this.

#### 3. Solution
- Used bind(this) to ensure that this.getTodoElement had the correct context when called within map.
Alternatively, using an arrow function to preserve the correct this context resolved the issue.

#### 4. Outcome
- The this binding was corrected, allowing the getTodoElement method to be properly executed during the map call, fixing the original issue.